### PR TITLE
Dockerfile and docker-compose fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Yazdan
 ENV DOCKYARD_SRC=. DOCKYARD_SRVHOME=/srv
 
 RUN apt-get update && apt-get -y upgrade && apt-get install -y \
-    python3 python3-pip python3-dev libmysqlclient-dev git libpq-dev && rm -rf /var/lib/apt/lists/*
+    python3 python3-pip python3-dev libmysqlclient-dev git libpq-dev binutils libproj-dev gdal-bin && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir $DOCKYARD_SRVHOME/media static logs
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   db:
-    image: postgres
+    image: postgis/postgis
     volumes:
       - db-data:/var/lib/postgresql/data
     restart: unless-stopped


### PR DESCRIPTION
so i made some changes for #39  like ([Geospatial libraries](https://docs.djangoproject.com/en/3.2/ref/contrib/gis/install/geolibs/) added to the Dockerfile for gdal error) and (change postgres image to [postgis](https://registry.hub.docker.com/r/postgis/postgis/) image because of some error for installing postgis extension in postgresql)
i faced this errors when i was trying to make a container from docker-compose
i tag some photo of these steps:
*****gdal error*****
![Screenshot from 2021-05-29 18-45-54](https://user-images.githubusercontent.com/15687474/120205983-dd82d800-c23f-11eb-9178-762257a6f003.png)

*****FINAL LOG after fixing*****
![docker-compose logs](https://user-images.githubusercontent.com/15687474/120204933-9c3df880-c23e-11eb-9c1c-bf1261a03fca.png)
hope it will help
sorry for bad explanations
